### PR TITLE
CAM: Have results show immediately when finishing the passage

### DIFF
--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -49,7 +49,7 @@ toAscii tabWidth = concatMap toAscii'
       | otherwise = ""
 
 trimEmptyLines :: String -> String
-trimEmptyLines = (++ "\n") . f . f
+trimEmptyLines = f . f
   where
     f = reverse . dropWhile (== '\n')
 


### PR DESCRIPTION
## What

Results weren't showing up after finishing the passage, you had to hit enter first which was annoying.