### PR TITLE
CAM: Getting countdown timer to work + game state timer

### DIFF
--- a/app/TypingTest.hs
+++ b/app/TypingTest.hs
@@ -29,6 +29,7 @@ import           Data.List  (groupBy, isPrefixOf)
 import           Data.Maybe (fromJust, isJust)
 import           Data.Time  (UTCTime, diffUTCTime)
 import GHC.Read (readField)
+import Control.Concurrent (ThreadId, forkIO, threadDelay)
 
 -- It is often useful to know whether the line / character etc we are
 -- considering is "BeforeCursor" or "AfterCursor". More granularity turns out
@@ -50,6 +51,8 @@ data State =
     , screenWidth    :: Int
     -- screen width
     , carWidth    :: Int
+    -- count down timer
+    , counter    :: Int
     -- time when the user started typing
     , start   :: Maybe UTCTime
     , end     :: Maybe UTCTime
@@ -146,6 +149,7 @@ initialState target car =
   State
     { target = target
     , car = car
+    , counter = 0
     , screenWidth = maximum (map length (lines target))
     , carWidth = maximum (map length (lines car))
     , input = takeWhile isSpace target

--- a/app/TypingTest.hs
+++ b/app/TypingTest.hs
@@ -13,7 +13,8 @@ module TypingTest
   , cursorRow
   , countChars
   , hasEnded
-  , hasStarted
+  , hasGameStarted
+  , hasStartedTyping
   , initialState
   , isComplete
   , onLastLine
@@ -27,7 +28,7 @@ module TypingTest
 import           Data.Char  (isSpace)
 import           Data.List  (groupBy, isPrefixOf)
 import           Data.Maybe (fromJust, isJust)
-import           Data.Time  (UTCTime, diffUTCTime)
+import           Data.Time  (UTCTime (UTCTime), diffUTCTime, getCurrentTime, fromGregorian, secondsToDiffTime)
 import GHC.Read (readField)
 import Control.Concurrent (ThreadId, forkIO, threadDelay)
 
@@ -53,6 +54,12 @@ data State =
     , carWidth    :: Int
     -- count down timer
     , counter    :: Int
+    -- how much we should count down by before starting
+    , howMuchOnCounter :: Int
+    -- time when the game should start
+    , startGameTime   :: UTCTime
+    -- current time
+    , currentTime   :: UTCTime
     -- time when the user started typing
     , start   :: Maybe UTCTime
     , end     :: Maybe UTCTime
@@ -79,8 +86,12 @@ startClock now s = s {start = Just now}
 stopClock :: UTCTime -> State -> State
 stopClock now s = s {end = Just now}
 
-hasStarted :: State -> Bool
-hasStarted = isJust . start
+hasGameStarted :: State -> Bool
+hasGameStarted state = 
+  startGameTime state <= currentTime state
+
+hasStartedTyping :: State -> Bool
+hasStartedTyping = isJust . start
 
 hasEnded :: State -> Bool
 hasEnded = isJust . end
@@ -155,6 +166,9 @@ initialState target car =
     , input = takeWhile isSpace target
     , start = Nothing
     , end = Nothing
+    , howMuchOnCounter = 5
+    , startGameTime = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0)
+    , currentTime = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0)
     , strokes = 0
     , hits = 0
     , loop = False

--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -49,7 +49,7 @@ toAscii tabWidth = concatMap toAscii'
       | otherwise = ""
 
 trimEmptyLines :: String -> String
-trimEmptyLines = (++ "\n") . f . f
+trimEmptyLines = f . f
   where
     f = reverse . dropWhile (== '\n')
 


### PR DESCRIPTION
## What

When the app starts up, we'll have a timer count down to 0 before we can start typing.

I also added a game loop (very hacky), meaning we'll be able to update our state independently of key/mouse events. I set it to run at a 30 fps rate so far. 